### PR TITLE
Store and cluster HCL colors

### DIFF
--- a/cmd/palettor/palettor.go
+++ b/cmd/palettor/palettor.go
@@ -64,7 +64,7 @@ func main() {
 
 	palette, err := palettor.Extract(*k, *maxIters, img)
 	if err != nil {
-		log.Fatalf("Error extracing color palette: %s", err)
+		log.Fatalf("Error extracting color palette: %s", err)
 	}
 
 	if *jsonOutput {

--- a/hcl.go
+++ b/hcl.go
@@ -19,6 +19,8 @@ func (c hclColor) toColorfulColor() colorful.Color {
 	}
 }
 
+// Calculate the square of the Euclidean distance between two colors, ignoring
+// the alpha channel.
 func (c hclColor) distanceSquared(other hclColor) float64 {
 	dh := c.h - other.h
 	dc := c.c - other.c

--- a/hcl.go
+++ b/hcl.go
@@ -1,0 +1,23 @@
+package palettor
+
+import "github.com/lucasb-eyer/go-colorful"
+
+type hclColor struct {
+	h, c, l float64
+}
+
+func (c hclColor) toColorfulColor() colorful.Color {
+	return colorful.Hcl(c.h, c.c, c.l)
+}
+
+func (c hclColor) distanceSquared(other hclColor) float64 {
+	dh := c.h - other.h
+	dc := c.c - other.c
+	dl := c.l - other.l
+	return dh*dh + dc*dc + dl*dl
+}
+
+func toHCL(color colorful.Color) hclColor {
+	h, c, l := color.Hcl()
+	return hclColor{h, c, l}
+}

--- a/hcl.go
+++ b/hcl.go
@@ -16,12 +16,7 @@ func (c hcl) RGBA() (r, g, b, a uint32) {
 	// Bodge: squash floating point error to simplify testing with expected
 	// output palettes.
 	rFloat, gFloat, bFloat := colorful.Hcl(c.h, c.c, c.l).Clamped().RGB255()
-	intermediate := colorful.Color{
-		R: float64(rFloat / 255),
-		G: float64(gFloat / 255),
-		B: float64(bFloat / 255),
-	}
-	return intermediate.RGBA()
+	return color.RGBA{rFloat, gFloat, bFloat, 255}.RGBA()
 }
 
 // Calculate the square of the Euclidean distance between two colors, ignoring

--- a/hcl.go
+++ b/hcl.go
@@ -1,13 +1,22 @@
 package palettor
 
-import "github.com/lucasb-eyer/go-colorful"
+import (
+	"github.com/lucasb-eyer/go-colorful"
+)
 
 type hclColor struct {
 	h, c, l float64
 }
 
 func (c hclColor) toColorfulColor() colorful.Color {
-	return colorful.Hcl(c.h, c.c, c.l)
+	// Bodge: squash floating point error to simplify testing with expected
+	// output palettes.
+	r, g, b := colorful.Hcl(c.h, c.c, c.l).Clamped().RGB255()
+	return colorful.Color{
+		R: float64(r / 255),
+		G: float64(g / 255),
+		B: float64(b / 255),
+	}
 }
 
 func (c hclColor) distanceSquared(other hclColor) float64 {

--- a/hcl.go
+++ b/hcl.go
@@ -1,14 +1,16 @@
 package palettor
 
 import (
+	"image/color"
+
 	"github.com/lucasb-eyer/go-colorful"
 )
 
-type hclColor struct {
+type hcl struct {
 	h, c, l float64
 }
 
-func (c hclColor) toColorfulColor() colorful.Color {
+func (c hcl) toColor() color.Color {
 	// Bodge: squash floating point error to simplify testing with expected
 	// output palettes.
 	r, g, b := colorful.Hcl(c.h, c.c, c.l).Clamped().RGB255()
@@ -21,14 +23,14 @@ func (c hclColor) toColorfulColor() colorful.Color {
 
 // Calculate the square of the Euclidean distance between two colors, ignoring
 // the alpha channel.
-func (c hclColor) distanceSquared(other hclColor) float64 {
+func (c hcl) distanceSquared(other hcl) float64 {
 	dh := c.h - other.h
 	dc := c.c - other.c
 	dl := c.l - other.l
 	return dh*dh + dc*dc + dl*dl
 }
 
-func toHCL(color colorful.Color) hclColor {
+func toHCL(color colorful.Color) hcl {
 	h, c, l := color.Hcl()
-	return hclColor{h, c, l}
+	return hcl{h, c, l}
 }

--- a/hcl_test.go
+++ b/hcl_test.go
@@ -19,3 +19,19 @@ func TestDistanceSquared(t *testing.T) {
 	c := forceHCL(randomColor())
 	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
 }
+
+func TestColor(t *testing.T) {
+	assert.Implements(t, (*color.Color)(nil), new(hcl))
+
+	input := color.RGBA{123, 123, 123, 255}
+	inputR, inputG, inputB, inputA := input.RGBA()
+
+	c, err := toHCL(input)
+	assert.NoError(t, err)
+
+	r, g, b, a := c.RGBA()
+	assert.Equal(t, inputR, r)
+	assert.Equal(t, inputG, g)
+	assert.Equal(t, inputB, b)
+	assert.Equal(t, inputA, a)
+}

--- a/hcl_test.go
+++ b/hcl_test.go
@@ -1,21 +1,21 @@
 package palettor
 
 import (
+	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDistanceSquared(t *testing.T) {
-	a := toHCL(newColor(0, 0, 0, 255))
-	b := toHCL(newColor(255, 255, 255, 255))
-
+	a := forceHCL(color.RGBA{0, 0, 0, 255})
+	b := forceHCL(color.RGBA{255, 255, 255, 255})
 	assert.InDelta(t, 1, a.distanceSquared(b), .0001, "distance should be square of Euclidean distance")
 
-	a = toHCL(newColor(0, 0, 0, 1))
-	b = toHCL(newColor(0, 0, 0, 255))
+	a = forceHCL(color.RGBA{0, 0, 0, 1})
+	b = forceHCL(color.RGBA{0, 0, 0, 255})
 	assert.Equal(t, 0.00, a.distanceSquared(b), "alpha channel should be ignored for the purpose of distance")
 
-	c := toHCL(randomColor())
+	c := forceHCL(randomColor())
 	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
 }

--- a/hcl_test.go
+++ b/hcl_test.go
@@ -1,0 +1,21 @@
+package palettor
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDistanceSquared(t *testing.T) {
+	a := toHCL(newColor(0, 0, 0, 255))
+	b := toHCL(newColor(255, 255, 255, 255))
+
+	assert.InDelta(t, 1, a.distanceSquared(b), .0001, "distance should be square of Euclidean distance")
+
+	a = toHCL(newColor(0, 0, 0, 1))
+	b = toHCL(newColor(0, 0, 0, 255))
+	assert.Equal(t, 0.00, a.distanceSquared(b), "alpha channel should be ignored for the purpose of distance")
+
+	c := toHCL(randomColor())
+	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
+}

--- a/kmeans.go
+++ b/kmeans.go
@@ -45,12 +45,6 @@ func clusterColors(k, maxIterations int, outerColors []colorful.Color) (*Palette
 	}
 
 	// Convert back to colorful RGB space for output.
-	//
-	// NOTE: this conversion may really be unnecessary; it could be ideal just
-	// to use it as an intermediary (encapsulated with `hclColor`) to convert
-	// back to somthing implementing `color.Color`.
-	//
-	// Alternatively, `hclColor` could implement `color.Color` directly.
 	clusterWeights := make(map[colorful.Color]float64, k)
 	for centroid, cluster := range clusters {
 		clusterWeights[centroid.toColorfulColor()] = float64(len(cluster)) / float64(colorCount)
@@ -146,27 +140,11 @@ func nearest(needle hclColor, haystack []hclColor) hclColor {
 	var minDist float64
 	var result hclColor
 	for i, candidate := range haystack {
-		dist := distanceSquared(needle, candidate)
+		dist := needle.distanceSquared(candidate)
 		if i == 0 || dist < minDist {
 			minDist = dist
 			result = candidate
 		}
 	}
 	return result
-}
-
-// Calculate the square of the Euclidean distance between two colors, ignoring
-// the alpha channel.
-func distanceSquared(a, b hclColor) float64 {
-	// NOTE: consider using one of the (colorful.Color).DistanceX functions
-	// rather than homebrewing euclidean distance.
-	//
-	// + `DistanceCIEDE2000` is the most accurate, but slow.
-	// + `DistanceCIEDE2000klch` is the same, but allows specifying non-1 weights.
-	// + `DistanceLab` is essentially this code but with an additional square
-	// 	 root; That probably shouldn't matter for k-means.
-	//
-	// I suspect they're *all* slower than the euclidean distance here, but they
-	// may produce better results.
-	return a.distanceSquared(b)
 }

--- a/kmeans.go
+++ b/kmeans.go
@@ -131,14 +131,14 @@ func findCentroid(colors []hclColor) hclColor {
 
 // Find the average color in a list of colors.
 func meanColor(colors []hclColor) hclColor {
-	var h, c, l float64
+	var hSum, cSum, lSum float64
 	for _, color := range colors {
-		h += color.h
-		c += color.c
-		l += color.l
+		hSum += color.h
+		cSum += color.c
+		lSum += color.l
 	}
 	count := float64(len(colors))
-	return hclColor{h / count, c / count, l / count}
+	return hclColor{hSum / count, cSum / count, lSum / count}
 }
 
 // Find the item in the haystack to which the needle is closest.

--- a/kmeans.go
+++ b/kmeans.go
@@ -42,7 +42,7 @@ func clusterColors(k, maxIterations int, colors []hcl) (*Palette, error) {
 		converged:  converged,
 	}
 	for centroid, cluster := range clusters {
-		palette.add(centroid.toColor(), float64(len(cluster))/float64(colorCount))
+		palette.add(centroid, float64(len(cluster))/float64(colorCount))
 	}
 	return palette, nil
 }

--- a/kmeans.go
+++ b/kmeans.go
@@ -2,7 +2,6 @@ package palettor
 
 import (
 	"fmt"
-	"image/color"
 	"math/rand"
 	"time"
 )
@@ -37,16 +36,15 @@ func clusterColors(k, maxIterations int, colors []hcl) (*Palette, error) {
 		}
 	}
 
-	// Convert back to colorful RGB space for output.
-	clusterWeights := make(map[color.Color]float64, k)
-	for centroid, cluster := range clusters {
-		clusterWeights[centroid.toColor()] = float64(len(cluster)) / float64(colorCount)
+	// Build palette.
+	palette := &Palette{
+		iterations: iterations,
+		converged:  converged,
 	}
-	return &Palette{
-		colorWeights: clusterWeights,
-		iterations:   iterations,
-		converged:    converged,
-	}, nil
+	for centroid, cluster := range clusters {
+		palette.add(centroid.toColor(), float64(len(cluster))/float64(colorCount))
+	}
+	return palette, nil
 }
 
 // Generate the initial list of k centroids from the given list of colors.

--- a/kmeans.go
+++ b/kmeans.go
@@ -146,9 +146,17 @@ func nearest(needle colorful.Color, haystack []colorful.Color) colorful.Color {
 // Calculate the square of the Euclidean distance between two colors, ignoring
 // the alpha channel.
 func distanceSquared(a, b colorful.Color) float64 {
+	// NOTE: consider using one of the (colorful.Color).DistanceX functions
+	// rather than homebrewing euclidean distance.
+	//
+	// + `DistanceCIEDE2000` is the most accurate, but slow.
+	// + `DistanceCIEDE2000klch` is the same, but allows specifying non-1 weights.
+	// + `DistanceLab` is essentially this code but with an additional square
+	// 	 root; That probably shouldn't matter for k-means.
+	//
+	// I suspect they're *all* slower than the euclidean distance here, but they
+	// may produce better results.
 
-	// NOTE: is this really a decent HCL distance? H-values cover a much greater
-	// range than C and L values.
 	h1, c1, l1 := a.Hcl()
 	h2, c2, l2 := b.Hcl()
 

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -69,29 +69,16 @@ func TestDistanceSquared(t *testing.T) {
 func TestNearest(t *testing.T) {
 	var haystack = []hclColor{hclBlack, hclWhite, hclRed, hclGreen, hclBlue}
 
-	if nearest(hclBlack, haystack) != hclBlack {
-		t.Errorf("nearest color to self should be self")
-	}
-	if nearest(hclDarkGrey, haystack) != hclBlack {
-		t.Errorf("dark gray should be nearest to black")
-	}
-	if nearest(hclMostlyRed, haystack) != hclRed {
-		t.Errorf("mostly-red should be nearest to red")
-	}
+	assert.Equal(t, hclBlack, nearest(hclBlack, haystack), "nearest color to self should be self")
+	assert.Equal(t, hclBlack, nearest(hclDarkGrey, haystack), "dark gray should be nearest to black")
+	assert.Equal(t, hclRed, nearest(hclMostlyRed, haystack), "mostly-red should be nearest to red")
 }
 
 func TestFindCentroid(t *testing.T) {
 	var cluster = []hclColor{hclBlack, hclWhite, hclRed, hclMostlyRed}
 	centroid := findCentroid(cluster)
-	found := false
-	for _, c := range cluster {
-		if c == centroid {
-			found = true
-		}
-	}
-	if !found {
-		t.Errorf("centroid should be a member of the cluster")
-	}
+
+	assert.Contains(t, cluster, centroid, "centroid should be a member of the cluster")
 }
 
 func TestCluster(t *testing.T) {
@@ -99,36 +86,29 @@ func TestCluster(t *testing.T) {
 
 	k := 4
 	_, err := clusterColors(k, 100, colors)
-	if err == nil {
-		t.Errorf("too few colors should result in an error")
-	}
+	assert.Error(t, err, "too few colors should result in an error")
 
 	k = 3
 	palette, err := clusterColors(k, 100, colors)
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-	if palette.Count() != k {
-		t.Errorf("expected %d clusters, got %d", k, palette.Count())
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, k, palette.Count(), "got unexpected number of clusters")
 
 	k = 2
 	colors = []colorful.Color{black, white}
+	t.Logf("colors: %+v", colors)
+
 	palette, _ = clusterColors(k, 100, colors)
-	if palette.Weight(black) != 0.5 {
-		t.Errorf("expected weight of black cluster to be 0.5")
-	}
-	if palette.Weight(white) != 0.5 {
-		t.Errorf("expected weight of white cluster to be 0.5")
-	}
+
+	t.Logf("Palette: %+v", palette)
+
+	assert.Equal(t, 0.5, palette.Weight(black), "expected weight of black cluster to be 0.5")
+	assert.Equal(t, 0.5, palette.Weight(white), "expected weight of white cluster to be 0.5")
 
 	// If there are not enough unique colors to cluster, it's okay for the size
 	// of the extracted palette to be < k
 	k = 3
 	palette, _ = clusterColors(k, 100, []colorful.Color{black, black, black, black, black, white})
-	if palette.Count() > 2 {
-		t.Errorf("actual palette can be smaller than k")
-	}
+	assert.LessOrEqual(t, palette.Count(), 2, "actual palette can be smaller than k")
 }
 
 func BenchmarkClusterColors200x200(b *testing.B) {

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -23,7 +23,7 @@ var (
 	// HCL colors test internal behavior.
 	hclBlack     = toHCL(black)
 	hclWhite     = toHCL(white)
-	hclRed       = toHCL(red)
+	hclRed       = toHCL(newColor(255, 0, 0, 255))
 	hclGreen     = toHCL(newColor(0, 255, 0, 255))
 	hclBlue      = toHCL(newColor(0, 0, 255, 255))
 	hclDarkGrey  = toHCL(newColor(1, 1, 1, 255))
@@ -49,22 +49,8 @@ func newColor(r, g, b, a int) colorful.Color {
 	return color
 }
 
-func TestDistanceSquared(t *testing.T) {
-	a := toHCL(newColor(0, 0, 0, 255))
-	b := toHCL(newColor(255, 255, 255, 255))
-
-	assert.InDelta(t, 1, a.distanceSquared(b), .0001, "distance should be square of Euclidean distance")
-
-	a = toHCL(newColor(0, 0, 0, 1))
-	b = toHCL(newColor(0, 0, 0, 255))
-	assert.Equal(t, 0.00, a.distanceSquared(b), "alpha channel should be ignored for the purpose of distance")
-
-	c := toHCL(randomColor())
-	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
-}
-
 func TestNearest(t *testing.T) {
-	var haystack = []hclColor{hclBlack, hclWhite, hclRed, hclGreen, hclBlue}
+	var haystack = []hcl{hclBlack, hclWhite, hclRed, hclGreen, hclBlue}
 
 	assert.Equal(t, hclBlack, nearest(hclBlack, haystack), "nearest color to self should be self")
 	assert.Equal(t, hclBlack, nearest(hclDarkGrey, haystack), "dark gray should be nearest to black")
@@ -72,14 +58,14 @@ func TestNearest(t *testing.T) {
 }
 
 func TestFindCentroid(t *testing.T) {
-	var cluster = []hclColor{hclBlack, hclWhite, hclRed, hclMostlyRed}
+	var cluster = []hcl{hclBlack, hclWhite, hclRed, hclMostlyRed}
 	centroid := findCentroid(cluster)
 
 	assert.Contains(t, cluster, centroid, "centroid should be a member of the cluster")
 }
 
 func TestCluster(t *testing.T) {
-	var colors = []colorful.Color{black, white, red}
+	var colors = []hcl{hclBlack, hclWhite, hclRed}
 
 	k := 4
 	_, err := clusterColors(k, 100, colors)
@@ -91,20 +77,15 @@ func TestCluster(t *testing.T) {
 	assert.Equal(t, k, palette.Count(), "got unexpected number of clusters")
 
 	k = 2
-	colors = []colorful.Color{black, white}
-	t.Logf("colors: %+v", colors)
-
+	colors = []hcl{hclBlack, hclWhite}
 	palette, _ = clusterColors(k, 100, colors)
-
-	t.Logf("Palette: %+v", palette)
-
 	assert.Equal(t, 0.5, palette.Weight(black), "expected weight of black cluster to be 0.5")
 	assert.Equal(t, 0.5, palette.Weight(white), "expected weight of white cluster to be 0.5")
 
 	// If there are not enough unique colors to cluster, it's okay for the size
 	// of the extracted palette to be < k
 	k = 3
-	palette, _ = clusterColors(k, 100, []colorful.Color{black, black, black, black, black, white})
+	palette, _ = clusterColors(k, 100, []hcl{hclBlack, hclBlack, hclBlack, hclBlack, hclBlack, hclWhite})
 	assert.LessOrEqual(t, palette.Count(), 2, "actual palette can be smaller than k")
 }
 

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -14,23 +14,20 @@ import (
 )
 
 var (
-	r         = rand.New(rand.NewSource(time.Now().UnixNano()))
-	black     = newColor(0, 0, 0, 255)
-	white     = newColor(255, 255, 255, 255)
-	red       = newColor(255, 0, 0, 255)
-	green     = newColor(0, 255, 0, 255)
-	blue      = newColor(0, 0, 255, 255)
-	darkGray  = newColor(1, 1, 1, 255)
-	mostlyRed = newColor(200, 0, 0, 255)
+	r = rand.New(rand.NewSource(time.Now().UnixNano()))
 
-	// FIXME: Bodge; restandardize this interface.
+	black = newColor(0, 0, 0, 255)
+	white = newColor(255, 255, 255, 255)
+	red   = newColor(255, 0, 0, 255)
+
+	// HCL colors test internal behavior.
 	hclBlack     = toHCL(black)
 	hclWhite     = toHCL(white)
 	hclRed       = toHCL(red)
-	hclGreen     = toHCL(green)
-	hclBlue      = toHCL(blue)
-	hclDarkGrey  = toHCL(darkGray)
-	hclMostlyRed = toHCL(mostlyRed)
+	hclGreen     = toHCL(newColor(0, 255, 0, 255))
+	hclBlue      = toHCL(newColor(0, 0, 255, 255))
+	hclDarkGrey  = toHCL(newColor(1, 1, 1, 255))
+	hclMostlyRed = toHCL(newColor(200, 0, 0, 255))
 )
 
 func randomColor() colorful.Color {
@@ -56,14 +53,14 @@ func TestDistanceSquared(t *testing.T) {
 	a := toHCL(newColor(0, 0, 0, 255))
 	b := toHCL(newColor(255, 255, 255, 255))
 
-	assert.InDelta(t, 1, distanceSquared(a, b), .0001, "distance should be square of Euclidean distance")
+	assert.InDelta(t, 1, a.distanceSquared(b), .0001, "distance should be square of Euclidean distance")
 
 	a = toHCL(newColor(0, 0, 0, 1))
 	b = toHCL(newColor(0, 0, 0, 255))
-	assert.Equal(t, 0.00, distanceSquared(a, b), "alpha channel should be ignored for the purpose of distance")
+	assert.Equal(t, 0.00, a.distanceSquared(b), "alpha channel should be ignored for the purpose of distance")
 
 	c := toHCL(randomColor())
-	assert.Equal(t, 0.00, distanceSquared(c, c), "distance from between identical colors should be 0")
+	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
 }
 
 func TestNearest(t *testing.T) {

--- a/kmeans_test.go
+++ b/kmeans_test.go
@@ -22,6 +22,15 @@ var (
 	blue      = newColor(0, 0, 255, 255)
 	darkGray  = newColor(1, 1, 1, 255)
 	mostlyRed = newColor(200, 0, 0, 255)
+
+	// FIXME: Bodge; restandardize this interface.
+	hclBlack     = toHCL(black)
+	hclWhite     = toHCL(white)
+	hclRed       = toHCL(red)
+	hclGreen     = toHCL(green)
+	hclBlue      = toHCL(blue)
+	hclDarkGrey  = toHCL(darkGray)
+	hclMostlyRed = toHCL(mostlyRed)
 )
 
 func randomColor() colorful.Color {
@@ -44,35 +53,35 @@ func newColor(r, g, b, a int) colorful.Color {
 }
 
 func TestDistanceSquared(t *testing.T) {
-	a := newColor(0, 0, 0, 255)
-	b := newColor(255, 255, 255, 255)
+	a := toHCL(newColor(0, 0, 0, 255))
+	b := toHCL(newColor(255, 255, 255, 255))
 
 	assert.InDelta(t, 1, distanceSquared(a, b), .0001, "distance should be square of Euclidean distance")
 
-	a = newColor(0, 0, 0, 1)
-	b = newColor(0, 0, 0, 255)
+	a = toHCL(newColor(0, 0, 0, 1))
+	b = toHCL(newColor(0, 0, 0, 255))
 	assert.Equal(t, 0.00, distanceSquared(a, b), "alpha channel should be ignored for the purpose of distance")
 
-	c := randomColor()
+	c := toHCL(randomColor())
 	assert.Equal(t, 0.00, distanceSquared(c, c), "distance from between identical colors should be 0")
 }
 
 func TestNearest(t *testing.T) {
-	var haystack = []colorful.Color{black, white, red, green, blue}
+	var haystack = []hclColor{hclBlack, hclWhite, hclRed, hclGreen, hclBlue}
 
-	if nearest(black, haystack) != black {
+	if nearest(hclBlack, haystack) != hclBlack {
 		t.Errorf("nearest color to self should be self")
 	}
-	if nearest(darkGray, haystack) != black {
+	if nearest(hclDarkGrey, haystack) != hclBlack {
 		t.Errorf("dark gray should be nearest to black")
 	}
-	if nearest(mostlyRed, haystack) != red {
+	if nearest(hclMostlyRed, haystack) != hclRed {
 		t.Errorf("mostly-red should be nearest to red")
 	}
 }
 
 func TestFindCentroid(t *testing.T) {
-	var cluster = []colorful.Color{black, white, red, mostlyRed}
+	var cluster = []hclColor{hclBlack, hclWhite, hclRed, hclMostlyRed}
 	centroid := findCentroid(cluster)
 	found := false
 	for _, c := range cluster {

--- a/palette_test.go
+++ b/palette_test.go
@@ -13,8 +13,8 @@ func TestPalette(t *testing.T) {
 		converged:  converged,
 		iterations: iterations,
 	}
-	palette.add(hclBlack.toColor(), 0.75)
-	palette.add(hclWhite.toColor(), 0.25)
+	palette.add(black, 0.75)
+	palette.add(white, 0.25)
 
 	assert.Equal(t, 2, palette.Count())
 	assert.Equal(t, converged, palette.Converged())

--- a/palette_test.go
+++ b/palette_test.go
@@ -1,14 +1,14 @@
 package palettor
 
 import (
+	"image/color"
 	"testing"
 
-	"github.com/lucasb-eyer/go-colorful"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPalette(t *testing.T) {
-	colorWeights := map[colorful.Color]float64{
+	colorWeights := map[color.Color]float64{
 		black: 0.75,
 		white: 0.25,
 	}

--- a/palette_test.go
+++ b/palette_test.go
@@ -1,27 +1,22 @@
 package palettor
 
 import (
-	"image/color"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPalette(t *testing.T) {
-	colorWeights := map[color.Color]float64{
-		black: 0.75,
-		white: 0.25,
-	}
-
 	iterations := 1
 	converged := true
 	palette := &Palette{
-		colorWeights: colorWeights,
-		converged:    converged,
-		iterations:   iterations,
+		converged:  converged,
+		iterations: iterations,
 	}
+	palette.add(hclBlack.toColor(), 0.75)
+	palette.add(hclWhite.toColor(), 0.25)
 
-	assert.Equal(t, len(colorWeights), palette.Count())
+	assert.Equal(t, 2, palette.Count())
 	assert.Equal(t, converged, palette.Converged())
 	assert.Equal(t, iterations, palette.Iterations())
 
@@ -29,7 +24,7 @@ func TestPalette(t *testing.T) {
 	assert.Equal(t, 0.00, palette.Weight(red), "wrong weight for unknown color")
 
 	for _, color := range palette.Colors() {
-		assert.Contains(t, colorWeights, color)
+		assert.Contains(t, palette.entries, asKey(color))
 	}
 
 	// ensure entries are sorted by weight

--- a/palette_test.go
+++ b/palette_test.go
@@ -1,7 +1,6 @@
 package palettor
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/lucasb-eyer/go-colorful"
@@ -30,16 +29,7 @@ func TestPalette(t *testing.T) {
 	assert.Equal(t, 0.00, palette.Weight(red), "wrong weight for unknown color")
 
 	for _, color := range palette.Colors() {
-		found := false
-		for inputColor := range colorWeights {
-			if color == inputColor {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("missing color %v from palette", color)
-		}
+		assert.Contains(t, colorWeights, color)
 	}
 
 	// ensure entries are sorted by weight
@@ -47,7 +37,5 @@ func TestPalette(t *testing.T) {
 		{white, 0.25},
 		{black, 0.75},
 	}
-	if entries := palette.Entries(); !reflect.DeepEqual(entries, expectedEntries) {
-		t.Errorf("expected entries %v, got %v", expectedEntries, entries)
-	}
+	assert.Equal(t, expectedEntries, palette.Entries())
 }

--- a/palettor.go
+++ b/palettor.go
@@ -5,8 +5,6 @@ package palettor
 import (
 	"fmt"
 	"image"
-
-	"github.com/lucasb-eyer/go-colorful"
 )
 
 // Extract finds the k most dominant colors in the given image using the
@@ -25,14 +23,12 @@ func getColors(img image.Image) ([]hcl, error) {
 	pixelCount := (bounds.Max.X - bounds.Min.X) * (bounds.Max.Y - bounds.Min.Y)
 	colors := make([]hcl, pixelCount)
 	i := 0
+	var err error
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			color, ok := colorful.MakeColor(img.At(x, y))
-			if !ok {
-				// FIXME: presumably fails for images with transparency.
-				return nil, fmt.Errorf("pixel at (%v, %v) has a-channel 0", x, y)
+			if colors[i], err = toHCL(img.At(x, y)); err != nil {
+				return nil, fmt.Errorf("error translating pixel at (%v, %v): %w", x, y, err)
 			}
-			colors[i] = toHCL(color)
 			i++
 		}
 	}

--- a/palettor.go
+++ b/palettor.go
@@ -20,18 +20,19 @@ func Extract(k, maxIterations int, img image.Image) (*Palette, error) {
 	return clusterColors(k, maxIterations, imgColors)
 }
 
-func getColors(img image.Image) ([]colorful.Color, error) {
+func getColors(img image.Image) ([]hcl, error) {
 	bounds := img.Bounds()
 	pixelCount := (bounds.Max.X - bounds.Min.X) * (bounds.Max.Y - bounds.Min.Y)
-	colors := make([]colorful.Color, pixelCount)
+	colors := make([]hcl, pixelCount)
 	i := 0
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			var ok bool
-			if colors[i], ok = colorful.MakeColor(img.At(x, y)); !ok {
+			color, ok := colorful.MakeColor(img.At(x, y))
+			if !ok {
 				// FIXME: presumably fails for images with transparency.
 				return nil, fmt.Errorf("pixel at (%v, %v) has a-channel 0", x, y)
 			}
+			colors[i] = toHCL(color)
 			i++
 		}
 	}

--- a/palettor_test.go
+++ b/palettor_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/base64"
 	"image/png"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // base64-encoded 4x4 png, w/ black, white, red, & blue pixels
@@ -18,12 +20,8 @@ func TestExtract(t *testing.T) {
 	}
 
 	_, err = Extract(5, 100, img)
-	if err == nil {
-		t.Errorf("k too large, expected an error")
-	}
+	assert.Error(t, err, "should error when k is too large")
 
 	palette, _ := Extract(4, 100, img)
-	if palette.Count() != 4 {
-		t.Errorf("expected 4 colors, got %d", palette.Count())
-	}
+	assert.Equal(t, 4, palette.Count())
 }


### PR DESCRIPTION
## Changes

+ Introduces an internal `hcl` struct; uses those to do the math.
+ Reverts the external interface to use `color.Color` rather than `colorful.Color`.
  + The latter remains a dependency; it's useful for converting things into the HCL space and for doing tricky `float64` rounding.

Changes Palette keys: use a structure calculated from the `color.Color` interface rather than depending on the caller providing the same implementation.

Converts remaining `t.Errorf` calls into `testify` assertions.

## Motivation

Performance. Eliminate `(colorful.Color).Hcl()` conversion in every comparison; that repeats a great deal of arithmetic.

## Testing

Benchmarking is the key here. The feature branch is meaningfully faster than `main`.

### Main branch

```
» go test -bench=. -count 50
goos: darwin
goarch: amd64
pkg: github.com/mccutchen/palettor
cpu: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
BenchmarkClusterColors200x200-8                1        6519113801 ns/op
BenchmarkClusterColors200x200-8                1        5605880550 ns/op
BenchmarkClusterColors200x200-8                1        7418678646 ns/op
BenchmarkClusterColors200x200-8                1        3955729945 ns/op
BenchmarkClusterColors200x200-8                1        7951561470 ns/op
BenchmarkClusterColors200x200-8                1        6997240273 ns/op
BenchmarkClusterColors200x200-8                1        5006206134 ns/op
BenchmarkClusterColors200x200-8                1        5086347820 ns/op
BenchmarkClusterColors200x200-8                1        2888422212 ns/op
BenchmarkClusterColors200x200-8                1        4492166161 ns/op
BenchmarkClusterColors200x200-8                1        1807498457 ns/op
BenchmarkClusterColors200x200-8                1        3077898340 ns/op
BenchmarkClusterColors200x200-8                1        3800273760 ns/op
BenchmarkClusterColors200x200-8                1        5050592162 ns/op
BenchmarkClusterColors200x200-8                1        5573954846 ns/op
BenchmarkClusterColors200x200-8                1        5758937158 ns/op
BenchmarkClusterColors200x200-8                1        5565257711 ns/op
BenchmarkClusterColors200x200-8                1        3753993015 ns/op
BenchmarkClusterColors200x200-8                1        2694610657 ns/op
BenchmarkClusterColors200x200-8                1        1437287704 ns/op
BenchmarkClusterColors200x200-8                1        2335908163 ns/op
BenchmarkClusterColors200x200-8                1        2670588822 ns/op
BenchmarkClusterColors200x200-8                1        1072847085 ns/op
BenchmarkClusterColors200x200-8                2        6033562010 ns/op
BenchmarkClusterColors200x200-8                1        2344311301 ns/op
BenchmarkClusterColors200x200-8                1        5945273530 ns/op
BenchmarkClusterColors200x200-8                1        5975498052 ns/op
BenchmarkClusterColors200x200-8                2        4205185498 ns/op
BenchmarkClusterColors200x200-8                1        5384902555 ns/op
BenchmarkClusterColors200x200-8                1        4824697267 ns/op
BenchmarkClusterColors200x200-8                1        3533124613 ns/op
BenchmarkClusterColors200x200-8                1        3816680802 ns/op
BenchmarkClusterColors200x200-8                1        3615794189 ns/op
BenchmarkClusterColors200x200-8                1        3504035948 ns/op
BenchmarkClusterColors200x200-8                1        7761513671 ns/op
BenchmarkClusterColors200x200-8                1        4509974015 ns/op
BenchmarkClusterColors200x200-8                1        4686784075 ns/op
BenchmarkClusterColors200x200-8                1        1213643839 ns/op
BenchmarkClusterColors200x200-8                1        3980257217 ns/op
BenchmarkClusterColors200x200-8                1        4314762744 ns/op
BenchmarkClusterColors200x200-8                1        3265144637 ns/op
BenchmarkClusterColors200x200-8                1        1086214722 ns/op
BenchmarkClusterColors200x200-8                1        4130062733 ns/op
BenchmarkClusterColors200x200-8                1        4704275493 ns/op
BenchmarkClusterColors200x200-8                1        3959606657 ns/op
BenchmarkClusterColors200x200-8                1        2170117429 ns/op
BenchmarkClusterColors200x200-8                1        7920757460 ns/op
BenchmarkClusterColors200x200-8                1        2889004191 ns/op
BenchmarkClusterColors200x200-8                1        4308193470 ns/op
BenchmarkClusterColors200x200-8                1        4136279373 ns/op
PASS
ok      github.com/mccutchen/palettor   227.296s
```

### Feature branch

```
» go test -bench=. -count 50                                                  130 ↵
goos: darwin
goarch: amd64
pkg: github.com/mccutchen/palettor
cpu: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
BenchmarkClusterColors200x200-8                8         141465252 ns/op
BenchmarkClusterColors200x200-8                7         154933923 ns/op
BenchmarkClusterColors200x200-8               16         139983655 ns/op
BenchmarkClusterColors200x200-8                9         221518464 ns/op
BenchmarkClusterColors200x200-8                7         182572243 ns/op
BenchmarkClusterColors200x200-8                6         205058521 ns/op
BenchmarkClusterColors200x200-8                7         177853351 ns/op
BenchmarkClusterColors200x200-8                7         187610008 ns/op
BenchmarkClusterColors200x200-8                8         137508456 ns/op
BenchmarkClusterColors200x200-8                7         152000701 ns/op
BenchmarkClusterColors200x200-8                7         180228910 ns/op
BenchmarkClusterColors200x200-8                8         143744930 ns/op
BenchmarkClusterColors200x200-8               20         134204662 ns/op
BenchmarkClusterColors200x200-8               22         136957372 ns/op
BenchmarkClusterColors200x200-8               10         121268331 ns/op
BenchmarkClusterColors200x200-8                8         131232975 ns/op
BenchmarkClusterColors200x200-8                9         124893432 ns/op
BenchmarkClusterColors200x200-8                8         166215846 ns/op
BenchmarkClusterColors200x200-8                8         152424459 ns/op
BenchmarkClusterColors200x200-8                8         148301368 ns/op
BenchmarkClusterColors200x200-8               12         127523219 ns/op
BenchmarkClusterColors200x200-8                8         137438341 ns/op
BenchmarkClusterColors200x200-8                7         142987110 ns/op
BenchmarkClusterColors200x200-8                7         142954036 ns/op
BenchmarkClusterColors200x200-8                9         205987775 ns/op
BenchmarkClusterColors200x200-8                7         247402828 ns/op
BenchmarkClusterColors200x200-8                9         163876426 ns/op
BenchmarkClusterColors200x200-8                6         168432196 ns/op
BenchmarkClusterColors200x200-8                7         144184916 ns/op
BenchmarkClusterColors200x200-8                9         149228227 ns/op
BenchmarkClusterColors200x200-8                6         204505257 ns/op
BenchmarkClusterColors200x200-8               10         125873750 ns/op
BenchmarkClusterColors200x200-8                8         137087913 ns/op
BenchmarkClusterColors200x200-8                7         183215229 ns/op
BenchmarkClusterColors200x200-8                8         133478232 ns/op
BenchmarkClusterColors200x200-8                8         128612259 ns/op
BenchmarkClusterColors200x200-8                6         171642608 ns/op
BenchmarkClusterColors200x200-8                9         130102117 ns/op
BenchmarkClusterColors200x200-8                8         127925104 ns/op
BenchmarkClusterColors200x200-8                9         146129941 ns/op
BenchmarkClusterColors200x200-8               10         129665213 ns/op
BenchmarkClusterColors200x200-8                9         152976485 ns/op
BenchmarkClusterColors200x200-8               10         138775919 ns/op
BenchmarkClusterColors200x200-8               10         113574827 ns/op
BenchmarkClusterColors200x200-8               12         167496035 ns/op
BenchmarkClusterColors200x200-8                9         126941312 ns/op
BenchmarkClusterColors200x200-8               10         127517906 ns/op
BenchmarkClusterColors200x200-8                9         119654591 ns/op
BenchmarkClusterColors200x200-8               13         138606553 ns/op
BenchmarkClusterColors200x200-8                9         122065177 ns/op
PASS
ok      github.com/mccutchen/palettor   106.568s
```

### Upstream: https://github.com/mccutchen/palettor

**Fastest.** 

```
» go test -bench=. -count 50 
goos: darwin
goarch: amd64
pkg: github.com/mccutchen/palettor
cpu: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
BenchmarkClusterColors200x200-8               21          71226706 ns/op
BenchmarkClusterColors200x200-8               20          71344269 ns/op
BenchmarkClusterColors200x200-8               16          71590876 ns/op
BenchmarkClusterColors200x200-8               14          74796578 ns/op
BenchmarkClusterColors200x200-8               18          65892808 ns/op
BenchmarkClusterColors200x200-8               13          80401778 ns/op
BenchmarkClusterColors200x200-8               16          87136033 ns/op
BenchmarkClusterColors200x200-8               13          88612752 ns/op
BenchmarkClusterColors200x200-8               16          79735481 ns/op
BenchmarkClusterColors200x200-8               18          82049303 ns/op
BenchmarkClusterColors200x200-8               16          83858381 ns/op
BenchmarkClusterColors200x200-8               13          78747059 ns/op
BenchmarkClusterColors200x200-8               19          74352155 ns/op
BenchmarkClusterColors200x200-8               18          79203238 ns/op
BenchmarkClusterColors200x200-8               33          75058950 ns/op
BenchmarkClusterColors200x200-8               16          69973674 ns/op
BenchmarkClusterColors200x200-8               14          91500526 ns/op
BenchmarkClusterColors200x200-8               30          75169462 ns/op
BenchmarkClusterColors200x200-8               15          97982457 ns/op
BenchmarkClusterColors200x200-8               34          87101675 ns/op
BenchmarkClusterColors200x200-8               24          84330936 ns/op
BenchmarkClusterColors200x200-8               22          80703853 ns/op
BenchmarkClusterColors200x200-8               14          81377294 ns/op
BenchmarkClusterColors200x200-8               18          75697959 ns/op
BenchmarkClusterColors200x200-8               20          79159979 ns/op
BenchmarkClusterColors200x200-8               16          80924889 ns/op
BenchmarkClusterColors200x200-8               24          71811977 ns/op
BenchmarkClusterColors200x200-8               16          78375914 ns/op
BenchmarkClusterColors200x200-8               14          93076243 ns/op
BenchmarkClusterColors200x200-8               15          84653498 ns/op
BenchmarkClusterColors200x200-8               20          87024183 ns/op
BenchmarkClusterColors200x200-8               22         102257044 ns/op
BenchmarkClusterColors200x200-8               42          81639702 ns/op
BenchmarkClusterColors200x200-8               12          88027883 ns/op
BenchmarkClusterColors200x200-8               13          79795435 ns/op
BenchmarkClusterColors200x200-8               14          85447537 ns/op
BenchmarkClusterColors200x200-8               16          96993591 ns/op
BenchmarkClusterColors200x200-8               18          67868347 ns/op
BenchmarkClusterColors200x200-8               15          99481045 ns/op
BenchmarkClusterColors200x200-8               15          86052748 ns/op
BenchmarkClusterColors200x200-8               18          76951712 ns/op
BenchmarkClusterColors200x200-8               28          83597216 ns/op
BenchmarkClusterColors200x200-8               28          85207041 ns/op
BenchmarkClusterColors200x200-8               16          77592274 ns/op
BenchmarkClusterColors200x200-8               34          76253448 ns/op
BenchmarkClusterColors200x200-8               24          92412718 ns/op
BenchmarkClusterColors200x200-8               14          75607424 ns/op
BenchmarkClusterColors200x200-8               15          91931917 ns/op
BenchmarkClusterColors200x200-8               15          91692787 ns/op
BenchmarkClusterColors200x200-8               18          81434954 ns/op
PASS
ok      github.com/mccutchen/palettor   102.323s
```
