### PR TITLE
Calculate mean hue and hue distance in circular space

### DIFF
--- a/hcl_test.go
+++ b/hcl_test.go
@@ -35,3 +35,13 @@ func TestColor(t *testing.T) {
 	assert.Equal(t, inputB, b)
 	assert.Equal(t, inputA, a)
 }
+
+func TestMeanHue(t *testing.T) {
+	// Reproduces example: https://en.wikipedia.org/wiki/Circular_mean#Example
+	result := meanHue([]hcl{
+		{h: 355},
+		{h: 5},
+		{h: 15},
+	})
+	assert.InDelta(t, 5, result, 0.001)
+}

--- a/hcl_test.go
+++ b/hcl_test.go
@@ -20,6 +20,18 @@ func TestDistanceSquared(t *testing.T) {
 	assert.Equal(t, 0.00, c.distanceSquared(c), "distance from between identical colors should be 0")
 }
 
+func TestHueDistance(t *testing.T) {
+	c := forceHCL(randomColor())
+	assert.InDelta(t, 0, c.hueDistance(c), 0.001, "zero distance between color and itself")
+
+	// Known distances.
+	assert.InDelta(t, 0, hcl{h: 0}.hueDistance(hcl{h: 360}), 0.001, "0 and 360 coincide in m360 space")
+	assert.InDelta(t, 100, hcl{h: 0}.hueDistance(hcl{h: 100}), 0.001)
+
+	assert.InDelta(t, 10, hcl{h: 5}.hueDistance(hcl{h: 355}), 0.001)
+	assert.InDelta(t, 10, hcl{h: 5}.hueDistance(hcl{h: -5}), 0.001)
+}
+
 func TestColor(t *testing.T) {
 	assert.Implements(t, (*color.Color)(nil), new(hcl))
 

--- a/kmeans.go
+++ b/kmeans.go
@@ -110,20 +110,8 @@ func updateStep(clusters map[hcl][]hcl) (bool, []hcl) {
 // to instead use the actual mean of the given colors (which is likely
 // not actually present in those colors).
 func findCentroid(colors []hcl) hcl {
-	center := meanColor(colors)
+	center := mean(colors)
 	return nearest(center, colors)
-}
-
-// Find the average color in a list of colors.
-func meanColor(colors []hcl) hcl {
-	var hSum, cSum, lSum float64
-	for _, color := range colors {
-		hSum += color.h
-		cSum += color.c
-		lSum += color.l
-	}
-	count := float64(len(colors))
-	return hcl{hSum / count, cSum / count, lSum / count}
 }
 
 // Find the item in the haystack to which the needle is closest.


### PR DESCRIPTION
## Changes



## Motivation

I think this may be responsible for the muddy ochre/sepia colors I've been observing. Arithmetic means of `h`-values can be misleading:

+ The distance between 0° and 360° is properly 0°, _not_ 360°.
+ The distance between 5° and 355° is properly 10°, _not_ 350°.

## Testing

Anecdotally, producing palettes with greater hue variation. For the duck test image:

+ `#7b7a86`
+ `#ada3ae`
+ `#111718`
+ `#9b675a`
+ `#a29278`

![palette](https://user-images.githubusercontent.com/4955943/225976946-4518481a-3dad-411b-8533-d485ad4ef257.png)

### Performance

Meaningful slowdown, which I assume is a result of the changed distance function.

```
» go test -bench=. -count 50
goos: darwin
goarch: amd64
pkg: github.com/mccutchen/palettor
cpu: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
BenchmarkClusterColors200x200-8                2         988114310 ns/op
BenchmarkClusterColors200x200-8                2         864845458 ns/op
BenchmarkClusterColors200x200-8               20         865562105 ns/op
BenchmarkClusterColors200x200-8                3         644983656 ns/op
BenchmarkClusterColors200x200-8                3         612267490 ns/op
BenchmarkClusterColors200x200-8                2         887762812 ns/op
BenchmarkClusterColors200x200-8                2         866204094 ns/op
BenchmarkClusterColors200x200-8               12         699872761 ns/op
BenchmarkClusterColors200x200-8                2         910219301 ns/op
BenchmarkClusterColors200x200-8                2         910231966 ns/op
BenchmarkClusterColors200x200-8                3         638277917 ns/op
BenchmarkClusterColors200x200-8               25         890054165 ns/op
BenchmarkClusterColors200x200-8                2         900191048 ns/op
BenchmarkClusterColors200x200-8               13         515988675 ns/op
BenchmarkClusterColors200x200-8                2         918871784 ns/op
BenchmarkClusterColors200x200-8                3         896951858 ns/op
BenchmarkClusterColors200x200-8                1        1024883449 ns/op
BenchmarkClusterColors200x200-8                3         616764583 ns/op
BenchmarkClusterColors200x200-8                3         891475225 ns/op
BenchmarkClusterColors200x200-8                2         928746986 ns/op
BenchmarkClusterColors200x200-8                2         888917863 ns/op
BenchmarkClusterColors200x200-8               20         802902376 ns/op
BenchmarkClusterColors200x200-8                9         701485999 ns/op
BenchmarkClusterColors200x200-8                2         869918239 ns/op
BenchmarkClusterColors200x200-8                9         697127440 ns/op
BenchmarkClusterColors200x200-8               13         889219306 ns/op
BenchmarkClusterColors200x200-8                2         872199922 ns/op
BenchmarkClusterColors200x200-8               31         723139749 ns/op
BenchmarkClusterColors200x200-8                2         880892858 ns/op
BenchmarkClusterColors200x200-8                2         535201934 ns/op
BenchmarkClusterColors200x200-8                3         595977805 ns/op
BenchmarkClusterColors200x200-8                2         874861976 ns/op
BenchmarkClusterColors200x200-8                2         877012030 ns/op
BenchmarkClusterColors200x200-8                2         877900734 ns/op
BenchmarkClusterColors200x200-8                2         868502407 ns/op
BenchmarkClusterColors200x200-8                2         872825850 ns/op
BenchmarkClusterColors200x200-8               14         666059503 ns/op
BenchmarkClusterColors200x200-8               12         708980004 ns/op
BenchmarkClusterColors200x200-8                6         898737718 ns/op
BenchmarkClusterColors200x200-8                2         896993672 ns/op
BenchmarkClusterColors200x200-8                3         639351518 ns/op
BenchmarkClusterColors200x200-8                7         689190518 ns/op
BenchmarkClusterColors200x200-8                2         889511833 ns/op
BenchmarkClusterColors200x200-8                2         982783198 ns/op
BenchmarkClusterColors200x200-8                2        1024776312 ns/op
BenchmarkClusterColors200x200-8                1        1003399010 ns/op
BenchmarkClusterColors200x200-8                2         857702698 ns/op
BenchmarkClusterColors200x200-8                2         520730694 ns/op
BenchmarkClusterColors200x200-8                3         600874997 ns/op
BenchmarkClusterColors200x200-8                2         851122270 ns/op
PASS
ok      github.com/mccutchen/palettor   255.586s
```

Compared to the 'feature branch' benchmarks here, this constitutes about a 10x slowdown: https://github.com/lukasschwab/palettor/pull/2