### PR TITLE
Draft-implement the Sarifuddin & Missaoui difference measure

### DIFF
--- a/hcl.go
+++ b/hcl.go
@@ -48,7 +48,7 @@ func (c hcl) distanceSquared(other hcl) float64 {
 	// "Then, we can determine A_CH as A_CH = ΔH + 8/50 = ΔH + 0.16."
 	parameterA_CH := deltaHue + 0.16
 	weightedDeltaLum := parameterA_L * (c.l - other.l)
-	chromaHueTerm := square(c.c) + square(other.c) - (2 * c.c * other.c * degrees(math.Cos(radians(deltaHue))))
+	chromaHueTerm := square(c.c) + square(other.c) - (2 * c.c * other.c * math.Cos(radians(deltaHue)))
 	return square(weightedDeltaLum) + (parameterA_CH * chromaHueTerm)
 }
 

--- a/hcl_test.go
+++ b/hcl_test.go
@@ -8,12 +8,8 @@ import (
 )
 
 func TestDistanceSquared(t *testing.T) {
-	a := forceHCL(color.RGBA{0, 0, 0, 255})
-	b := forceHCL(color.RGBA{255, 255, 255, 255})
-	assert.InDelta(t, 1, a.distanceSquared(b), .0001, "distance should be square of Euclidean distance")
-
-	a = forceHCL(color.RGBA{0, 0, 0, 1})
-	b = forceHCL(color.RGBA{0, 0, 0, 255})
+	a := forceHCL(color.RGBA{0, 0, 0, 1})
+	b := forceHCL(color.RGBA{0, 0, 0, 255})
 	assert.Equal(t, 0.00, a.distanceSquared(b), "alpha channel should be ignored for the purpose of distance")
 
 	c := forceHCL(randomColor())


### PR DESCRIPTION
## Changes

https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.125.3833

I think I probably won't merge:

1. I believe my implementation to be flawed, using the wrong C/L scales.
2. I think this will constitute a major slowdown.
3. Breaks the distance metric tests, though that's bound to happen with any improvement here.

## Motivation

Played with [weighting the distance metric](https://gist.github.com/lukasschwab/78936857e430eaa54d5fb2972710a301) to put more emphasis on chroma/luminance; scaling them by 50 seemed okay for my test images, but felt like guesswork.

There _is_ prior art here. The paper proposing HCL also proposes a distance measure. I try to implement it here.

## Testing

See example images linked above.

### Benchmark

Performance seems 1.5x worse than main:

```
» go test -bench=. -count 50
goos: darwin
goarch: amd64
pkg: github.com/mccutchen/palettor
cpu: Intel(R) Core(TM) i7-4850HQ CPU @ 2.30GHz
BenchmarkClusterColors200x200-8                1        1404745333 ns/op
BenchmarkClusterColors200x200-8                1        1670284913 ns/op
BenchmarkClusterColors200x200-8                1        1323680544 ns/op
BenchmarkClusterColors200x200-8                1        1323634775 ns/op
BenchmarkClusterColors200x200-8                1        1316668830 ns/op
BenchmarkClusterColors200x200-8                8        1241288100 ns/op
BenchmarkClusterColors200x200-8               13        1226387615 ns/op
BenchmarkClusterColors200x200-8                1        1355208773 ns/op
BenchmarkClusterColors200x200-8                1        1425849306 ns/op
BenchmarkClusterColors200x200-8                1        1462397706 ns/op
BenchmarkClusterColors200x200-8                1        1405732213 ns/op
BenchmarkClusterColors200x200-8                2        1387049006 ns/op
BenchmarkClusterColors200x200-8                1        1366836868 ns/op
BenchmarkClusterColors200x200-8                1        1380502982 ns/op
BenchmarkClusterColors200x200-8                1        1507906615 ns/op
BenchmarkClusterColors200x200-8                1        1390967909 ns/op
BenchmarkClusterColors200x200-8                1        1390528721 ns/op
BenchmarkClusterColors200x200-8                1        1336299970 ns/op
BenchmarkClusterColors200x200-8                1        1365673000 ns/op
BenchmarkClusterColors200x200-8                1        1433842953 ns/op
BenchmarkClusterColors200x200-8                8        1299985444 ns/op
BenchmarkClusterColors200x200-8                1        1407982177 ns/op
BenchmarkClusterColors200x200-8                1        1449027178 ns/op
BenchmarkClusterColors200x200-8                4        1363173666 ns/op
BenchmarkClusterColors200x200-8                1        1376619206 ns/op
BenchmarkClusterColors200x200-8                1        1671226646 ns/op
BenchmarkClusterColors200x200-8                2        1475906058 ns/op
BenchmarkClusterColors200x200-8                1        1376753872 ns/op
BenchmarkClusterColors200x200-8                2         740938538 ns/op
BenchmarkClusterColors200x200-8                1        1419596422 ns/op
BenchmarkClusterColors200x200-8                1        1369970608 ns/op
BenchmarkClusterColors200x200-8                1        1366353042 ns/op
BenchmarkClusterColors200x200-8                1        1343820673 ns/op
BenchmarkClusterColors200x200-8                1        1331055602 ns/op
BenchmarkClusterColors200x200-8                1        1314743068 ns/op
BenchmarkClusterColors200x200-8                1        1303569710 ns/op
BenchmarkClusterColors200x200-8                1        1306228649 ns/op
BenchmarkClusterColors200x200-8                1        1312753441 ns/op
BenchmarkClusterColors200x200-8                1        1320142775 ns/op
BenchmarkClusterColors200x200-8                9        1187555357 ns/op
BenchmarkClusterColors200x200-8                1        1331912453 ns/op
BenchmarkClusterColors200x200-8                1        1314417822 ns/op
BenchmarkClusterColors200x200-8                1        1298886092 ns/op
BenchmarkClusterColors200x200-8                1        1307111508 ns/op
BenchmarkClusterColors200x200-8                1        1306359691 ns/op
BenchmarkClusterColors200x200-8                1        1305057755 ns/op
BenchmarkClusterColors200x200-8                1        1303457966 ns/op
BenchmarkClusterColors200x200-8                1        1315861244 ns/op
BenchmarkClusterColors200x200-8                1        1308401217 ns/op
BenchmarkClusterColors200x200-8                1        1301986258 ns/op
PASS
ok      github.com/mccutchen/palettor   121.317s
```